### PR TITLE
use monospace font for code

### DIFF
--- a/src/_chat.scss
+++ b/src/_chat.scss
@@ -90,8 +90,6 @@ backdrop-filter: blur(10px);
     box-shadow: 0 0 3px 1px rgba(0, 0, 0, 0.483);
     border: 1px solid var(--surCordBorder); 
     background: rgba(41, 38, 39, 0.276);
-    font-family: 'SF Mono', SFMono-Regular, ui-monospace,
-    'DejaVu Sans Mono', Menlo, Consolas, monospace;
 }
 .embedFull-1HGV2S {
         background-color: transparent;
@@ -101,8 +99,6 @@ backdrop-filter: blur(10px);
         background: rgba(231, 234, 237, 0.436) !important; 
         box-shadow: 0 0 3px 1px rgba(0, 0, 0, 0.146);
         border: 1px solid rgba(249, 249, 249, 0.772); 
-        font-family: 'SF Mono', SFMono-Regular, ui-monospace,
-        'DejaVu Sans Mono', Menlo, Consolas, monospace;
     }
 }
 /* Nitro Claim a Gift, Join a Server */

--- a/src/_font.scss
+++ b/src/_font.scss
@@ -17,7 +17,7 @@ code,
 body, button, input, select, textarea, .base-ZDDK0g, .headerText-1qIDDT, .header-Imy05m, .container-q97qHp, .name-3Uvkvr, .text-md-bold-22PzaZ, .text-md-semibold-3xVVGu, .text-sm-medium-3Pz3rB, .text-sm-normal-3Zj3Iv, .text-xs-medium-2LRpEj, .text-xs-normal-3SiVjE {
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
   text-rendering: optimizeLegibility !important;
-  /* font-weight: bold; */
+  // font-weight: bold;
   text-transform: none;
 }
 

--- a/src/_font.scss
+++ b/src/_font.scss
@@ -4,19 +4,21 @@
 > Designed by Apple in California - SAN FRANSISCO DISPLAY - https://developer.apple.com/fonts/ 
 */
 
-.platform-osx * {
-  font-family: -apple-system, BlinkMacSystemFont, sans-serif !important;
+code,
+.inlineCode-ERyvy_,
+.after_inlineCode-2_JXPm,
+.before_inlineCode-1zngJj,
+.codeLine-2C-9aH,
+.codeBlockText-28BOxV {
+  font-family: "SF Mono", mono, monospace;
+}
+
+::placeholder, ::-webkit-input-placeholder,
+body, button, input, select, textarea, .base-ZDDK0g, .headerText-1qIDDT, .header-Imy05m, .container-q97qHp, .name-3Uvkvr, .text-md-bold-22PzaZ, .text-md-semibold-3xVVGu, .text-sm-medium-3Pz3rB, .text-sm-normal-3Zj3Iv, .text-xs-medium-2LRpEj, .text-xs-normal-3SiVjE {
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
   text-rendering: optimizeLegibility !important;
-  // font-weight: bold;
+  /* font-weight: bold; */
   text-transform: none;
 }
 
-.platform-linux *,
-.platform-win * {
-  font-family: "SF Pro Display", sans-serif !important;
-  text-rendering: optimizeLegibility !important;
-  // font-weight: bold;
-  text-transform: none;
-}
-
-@import url("https://v1.fontapi.ir/css/SFProDisplay");
+@import url("https://raw.githubusercontent.com/czarhex/SanFranciscoFontCSS/main/SFFont.css");

--- a/surCord.theme.css
+++ b/surCord.theme.css
@@ -77,22 +77,24 @@
 /* Uncomment the line below to use Apple's Emoji font */
 /* @import url(https://mwittrien.github.io/BetterDiscordAddons/Themes/EmojiReplace/base/Apple.css); */
 
-.platform-osx * {
-  font-family: -apple-system, BlinkMacSystemFont, sans-serif !important;
+code,
+.inlineCode-ERyvy_,
+.after_inlineCode-2_JXPm,
+.before_inlineCode-1zngJj,
+.codeLine-2C-9aH,
+.codeBlockText-28BOxV {
+  font-family: "SF Mono", mono, monospace;
+}
+
+::placeholder, ::-webkit-input-placeholder,
+body, button, input, select, textarea, .base-ZDDK0g, .headerText-1qIDDT, .header-Imy05m, .container-q97qHp, .name-3Uvkvr, .text-md-bold-22PzaZ, .text-md-semibold-3xVVGu, .text-sm-medium-3Pz3rB, .text-sm-normal-3Zj3Iv, .text-xs-medium-2LRpEj, .text-xs-normal-3SiVjE {
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
   text-rendering: optimizeLegibility !important;
   /* font-weight: bold; */
   text-transform: none;
 }
 
-.platform-linux *,
-.platform-win * {
-  font-family: "SF Pro Display", sans-serif !important;
-  text-rendering: optimizeLegibility !important;
-  /* font-weight: bold; */
-  text-transform: none;
-}
-
-@import url("https://v1.fontapi.ir/css/SFProDisplay");
+@import url("https://raw.githubusercontent.com/czarhex/SanFranciscoFontCSS/main/SFFont.css");
 
 /* 
 /////////////////////////////////////////

--- a/surCord.user.css
+++ b/surCord.user.css
@@ -56,12 +56,22 @@
 /* Uncomment the line below to use Apple's Emoji font */
 /* @import url(https://mwittrien.github.io/BetterDiscordAddons/Themes/EmojiReplace/base/Apple.css); */
 
-* {
-  font-family: "SF Pro Display", sans-serif !important;
+code,
+.inlineCode-ERyvy_,
+.after_inlineCode-2_JXPm,
+.before_inlineCode-1zngJj,
+.codeLine-2C-9aH,
+.codeBlockText-28BOxV {
+  font-family: "SF Mono", mono, monospace;
+}
+
+::placeholder, ::-webkit-input-placeholder,
+body, button, input, select, textarea, .base-ZDDK0g, .headerText-1qIDDT, .header-Imy05m, .container-q97qHp, .name-3Uvkvr, .text-md-bold-22PzaZ, .text-md-semibold-3xVVGu, .text-sm-medium-3Pz3rB, .text-sm-normal-3Zj3Iv, .text-xs-medium-2LRpEj, .text-xs-normal-3SiVjE {
+  font-family: "SF Pro Display", sans-serif;
   text-rendering: optimizeLegibility !important;
   /* font-weight: bold; */
   text-transform: none;
 }
 
-@import url("https://v1.fontapi.ir/css/SFProDisplay");
+@import url("https://raw.githubusercontent.com/czarhex/SanFranciscoFontCSS/main/SFFont.css");
 }


### PR DESCRIPTION
yeah... title... this should do the thing

proof:
![Screenshot from 2022-08-17 17-05-38](https://user-images.githubusercontent.com/76652465/185175327-90c88b98-2318-4aa7-ae11-c31dd76c2fef.png)
![Screenshot from 2022-08-17 17-09-30](https://user-images.githubusercontent.com/76652465/185175756-088eaacf-6210-4102-aac8-ca62c34f1dd4.png)
![Screenshot from 2022-08-17 17-15-53](https://user-images.githubusercontent.com/76652465/185177154-9f988d1a-facf-4f82-8d4b-470cd7347eef.png)


it may or may not use SF mono (in any case it'll just use discord's default mono font if SF mono is not found)

i also made a repo with all SF fonts it needs to import (this might be more reliable) but let me know if i should change it back to fontapi.ir