### PR TITLE
fix note area

### DIFF
--- a/src/_flyouts.scss
+++ b/src/_flyouts.scss
@@ -349,8 +349,13 @@
 /* Footers */
 .footer-31IekZ {
     background-color: transparent;
-  }
-  
+}
+
+/* Note field */
+.textarea-_59yqs {
+    padding: 10px;
+}
+
 /* Powercord/Replugged Notifications */
   .powercord-toast, .powercord-toast .contents .inner {
     background: rgba(0, 0, 0, 0.436); 

--- a/src/_flyouts.scss
+++ b/src/_flyouts.scss
@@ -351,7 +351,7 @@
     background-color: transparent;
 }
 
-/* Note field */
+/* Notes area */
 .textarea-_59yqs {
     padding: 10px;
 }


### PR DESCRIPTION
so the way i added padding to the "notes" area on profile flyouts sucked before, now I did it right



for lucism:
![Screenshot from 2022-08-18 22-27-48](https://user-images.githubusercontent.com/76652465/185489592-6820a923-6226-4de0-a0d9-658b0f63dce4.png)
![Screenshot from 2022-08-18 22-27-22](https://user-images.githubusercontent.com/76652465/185489601-1d8c7c98-ced7-4715-8d10-8d6c44b2a991.png)

