### PR TITLE
remove background hover in own user popout

### DIFF
--- a/src/_flyouts.scss
+++ b/src/_flyouts.scss
@@ -207,6 +207,10 @@
     }
 }
 
+.item-1OdjEX.colorDefault-CDqZdO:hover.hideInteraction-2jPGL_ {
+    background: none !important;
+}
+
 /* Search Options */
 .searchInput-3pIoTy {
     background: rgba(0, 0, 0, 0.436); 


### PR DESCRIPTION
# before
![Screenshot from 2022-08-28 23-35-05](https://user-images.githubusercontent.com/76652465/187095859-a7304a27-8cbc-42a5-9efb-4d210edc90a5.png)
# after
![Screenshot from 2022-08-28 23-36-12](https://user-images.githubusercontent.com/76652465/187095861-12979349-6da7-45a1-8edf-9a27b715ee83.png)

### background is still there for other elements on hover
![Screenshot from 2022-08-28 23-36-19](https://user-images.githubusercontent.com/76652465/187095864-c0b833b5-05d6-4488-bdcc-1e3b6065d060.png)

